### PR TITLE
allow setting the HTTP client of the AP client

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,6 +70,15 @@ type C struct {
 	errFn  CtxLogFn
 }
 
+func SetClient(httpclient *http.Client) optionFn {
+	return func(c *C) error {
+		if httpclient != nil {
+			c.c = httpclient
+		}
+		return nil
+	}
+}
+
 func SetInfoLogger(logFn CtxLogFn) optionFn {
 	return func(c *C) error {
 		if logFn != nil {
@@ -120,9 +129,9 @@ var defaultClient = &http.Client{
 }
 
 var defaultTransport http.RoundTripper = &http.Transport{
-	MaxIdleConns:          100,
-	IdleConnTimeout:       90 * time.Second,
-	MaxIdleConnsPerHost:   20,
+	MaxIdleConns:        100,
+	IdleConnTimeout:     90 * time.Second,
+	MaxIdleConnsPerHost: 20,
 	DialContext: (&net.Dialer{
 		// This is the TCP connect timeout in this instance.
 		Timeout: 2500 * time.Millisecond,

--- a/pub.go
+++ b/pub.go
@@ -279,4 +279,3 @@ func validateObject(o pub.Item) error {
 	}
 	return nil
 }
-


### PR DESCRIPTION
This creates a functional argument to set the *http.Client used by the ActivityPub Client. This allows library users to to construct and use an HTTP client which is capable of interacting with servers on Tor and I2P in a way which preserves client isolation, and which does not leak information to DNS providers.